### PR TITLE
Add texture accessors and gamedata

### DIFF
--- a/gamedata/studio_hdr.games.txt
+++ b/gamedata/studio_hdr.games.txt
@@ -1610,18 +1610,6 @@
                 "linux"     "4"
             }
 
-            "mstudiotexture_t::used"
-            {
-                "windows"	"8"
-                "linux"     "8"
-            }
-
-            "mstudiotexture_t::unused1"
-            {
-                "windows"	"12"
-                "linux"     "12"
-            }
-
             "sizeof::mstudiotexture_t"
             {
                 "windows"	"64"

--- a/gamedata/studio_hdr.games.txt
+++ b/gamedata/studio_hdr.games.txt
@@ -1595,6 +1595,38 @@
                 "windows"  "19"
                 "linux"    "19"
             }
+
+            // mstudiotexture_t
+
+            "mstudiotexture_t::sznameindex"
+            {
+                "windows"	"0"
+                "linux"     "0"
+            }
+
+            "mstudiotexture_t::flags"
+            {
+                "windows"	"4"
+                "linux"     "4"
+            }
+
+            "mstudiotexture_t::used"
+            {
+                "windows"	"8"
+                "linux"     "8"
+            }
+
+            "mstudiotexture_t::unused1"
+            {
+                "windows"	"12"
+                "linux"     "12"
+            }
+
+            "sizeof::mstudiotexture_t"
+            {
+                "windows"	"64"
+                "linux"     "64"
+            }
         }
     }
 

--- a/include/studio_hdr.inc
+++ b/include/studio_hdr.inc
@@ -1763,6 +1763,48 @@ enum struct mstudioflexcontrollerui_t
 	}
 }
 
+enum struct mstudiotexture_t
+{
+	int size;
+	Address sznameindex;
+	Address flags;
+	Address used;
+	Address unused1;
+
+	void LoadOffsets(GameData gamedata)
+	{
+		// [offset] mstudiotexture_t::sznameindex
+		if ((this.sznameindex = view_as<Address>(gamedata.GetOffset("mstudiotexture_t::sznameindex"))) == INVALID_ADDRESS_OFFSET)
+		{
+		    SetFailState("Failed to get 'mstudiotexture_t::sznameindex' offset.");
+		}
+
+		// [offset] mstudiotexture_t::flags
+		if ((this.flags = view_as<Address>(gamedata.GetOffset("mstudiotexture_t::flags"))) == INVALID_ADDRESS_OFFSET)
+		{
+		    SetFailState("Failed to get 'mstudiotexture_t::flags' offset.");
+		}
+
+		// [offset] mstudiotexture_t::used
+		if ((this.used = view_as<Address>(gamedata.GetOffset("mstudiotexture_t::used"))) == INVALID_ADDRESS_OFFSET)
+		{
+		    SetFailState("Failed to get 'mstudiotexture_t::used' offset.");
+		}
+
+		// [offset] mstudiotexture_t::unused1
+		if ((this.unused1 = view_as<Address>(gamedata.GetOffset("mstudiotexture_t::unused1"))) == INVALID_ADDRESS_OFFSET)
+		{
+		    SetFailState("Failed to get 'mstudiotexture_t::unused1' offset.");
+		}
+
+		// [sizeof] mstudiotexture_t
+		if ((this.size = gamedata.GetOffset("sizeof::mstudiotexture_t")) == -1)
+		{
+		    SetFailState("Failed to get 'mstudiotexture_t' sizeof.");
+		}
+	}
+}
+
 // Hold all offsets
 enum struct Offsets
 {
@@ -1804,6 +1846,8 @@ enum struct Offsets
 	mstudioanimblock_t mstudioanimblock_t;
 	// Flex Controller UI
 	mstudioflexcontrollerui_t mstudioflexcontrollerui_t;
+	// Texture
+	mstudiotexture_t mstudiotexture_t;
 
 	void LoadOffsets(GameData gamedata)
 	{
@@ -1826,6 +1870,7 @@ enum struct Offsets
 		this.mstudiomodelgroup_t.LoadOffsets(gamedata);
 		this.mstudioanimblock_t.LoadOffsets(gamedata);
 		this.mstudioflexcontrollerui_t.LoadOffsets(gamedata);
+		this.mstudiotexture_t.LoadOffsets(gamedata);
 	}
 }
 Offsets g_Offsets;
@@ -3679,6 +3724,71 @@ methodmap FlexControllerUI < AddressObject
 	}
 }
 
+// Texture //
+enum Texture
+{
+	NULL_TEXTURE
+}
+
+methodmap Texture < AddressObject
+{
+	public Texture(Address base, int index)
+	{
+		return view_as<Texture>(base + view_as<Address>(g_Offsets.mstudiotexture_t.size * index));
+	}
+
+	property int sznameindex
+	{
+		public get()
+		{
+			this.Validate();
+			
+			// 'this' [base] + 'sznameindex' [offset]
+			return LoadFromAddress(view_as<Address>(this) + g_Offsets.mstudiotexture_t.sznameindex, NumberType_Int32);
+		}
+	}
+
+	public void GetName(char[] buffer, int buffer_size)
+	{
+		this.Validate();
+		
+		LoadStringFromAddress(view_as<Address>(this) + view_as<Address>(this.sznameindex), buffer, buffer_size);
+	}
+
+	property int flags
+	{
+		public get()
+		{
+			this.Validate();
+			
+			// 'this' [base] + 'flags' [offset]
+			return LoadFromAddress(view_as<Address>(this) + g_Offsets.mstudiotexture_t.flags, NumberType_Int32);
+		}
+	}
+
+	property int used
+	{
+		public get()
+		{
+			this.Validate();
+			
+			// 'this' [base] + 'used' [offset]
+			return LoadFromAddress(view_as<Address>(this) + g_Offsets.mstudiotexture_t.used, NumberType_Int32);
+		}
+	}
+
+	property int unused1
+	{
+		public get()
+		{
+			this.Validate();
+			
+			// 'this' [base] + 'unused1' [offset]
+			return LoadFromAddress(view_as<Address>(this) + g_Offsets.mstudiotexture_t.unused1, NumberType_Int32);
+		}
+	}
+}
+
 // StudioHdr //
 enum StudioHdr
 {
@@ -4666,6 +4776,30 @@ methodmap StudioHdr < AddressObject
 		}
 
 		return NULL_FLEX_CONTROLLER_UI;
+	}
+
+	public Texture GetTexture(int index)
+	{
+		this.Validate();
+
+		if (0 <= index < this.numtextures)
+		{
+			return Texture(view_as<Address>(this) + view_as<Address>(this.textureindex), index);
+		}
+
+		return NULL_TEXTURE;
+	}
+	
+	public void GetCdTexture(int index, char[] buffer, int buffer_size)
+	{
+		this.Validate();
+
+		if (0 <= index < this.numcdtextures)
+		{
+			Address charptr = LoadFromAddress(view_as<Address>(this) + view_as<Address>(this.cdtextureindex + (index * 4)), NumberType_Int32);
+			LoadStringFromAddress(view_as<Address>(this) + charptr, buffer, buffer_size);
+		}
+		else ThrowError("Invalid index: %d (count: %d)", index, this.numcdtextures);
 	}
 	
 	// Objects [Find By Name]

--- a/include/studio_hdr.inc
+++ b/include/studio_hdr.inc
@@ -1768,8 +1768,6 @@ enum struct mstudiotexture_t
 	int size;
 	Address sznameindex;
 	Address flags;
-	Address used;
-	Address unused1;
 
 	void LoadOffsets(GameData gamedata)
 	{
@@ -1783,18 +1781,6 @@ enum struct mstudiotexture_t
 		if ((this.flags = view_as<Address>(gamedata.GetOffset("mstudiotexture_t::flags"))) == INVALID_ADDRESS_OFFSET)
 		{
 		    SetFailState("Failed to get 'mstudiotexture_t::flags' offset.");
-		}
-
-		// [offset] mstudiotexture_t::used
-		if ((this.used = view_as<Address>(gamedata.GetOffset("mstudiotexture_t::used"))) == INVALID_ADDRESS_OFFSET)
-		{
-		    SetFailState("Failed to get 'mstudiotexture_t::used' offset.");
-		}
-
-		// [offset] mstudiotexture_t::unused1
-		if ((this.unused1 = view_as<Address>(gamedata.GetOffset("mstudiotexture_t::unused1"))) == INVALID_ADDRESS_OFFSET)
-		{
-		    SetFailState("Failed to get 'mstudiotexture_t::unused1' offset.");
 		}
 
 		// [sizeof] mstudiotexture_t
@@ -3763,28 +3749,6 @@ methodmap Texture < AddressObject
 			
 			// 'this' [base] + 'flags' [offset]
 			return LoadFromAddress(view_as<Address>(this) + g_Offsets.mstudiotexture_t.flags, NumberType_Int32);
-		}
-	}
-
-	property int used
-	{
-		public get()
-		{
-			this.Validate();
-			
-			// 'this' [base] + 'used' [offset]
-			return LoadFromAddress(view_as<Address>(this) + g_Offsets.mstudiotexture_t.used, NumberType_Int32);
-		}
-	}
-
-	property int unused1
-	{
-		public get()
-		{
-			this.Validate();
-			
-			// 'this' [base] + 'unused1' [offset]
-			return LoadFromAddress(view_as<Address>(this) + g_Offsets.mstudiotexture_t.unused1, NumberType_Int32);
 		}
 	}
 }


### PR DESCRIPTION
Adds accessors for mstudiotexture_t (used vmt files) and cdtexture (vmt search paths).

I have only implemented parameters up to mstudiotexture_t::unused1 as the official SDK and the included generator inputs seemed to differ after it.
Gamedata for "sizeof::mstudiotexture_t" may be different for other games. I have only tested it in HL2DM.
There's still some potential for more data to be extracted out of the IMaterial reference if needed.

```
StudioHdr studiohdr = StudioHdr("...");
char texture[PLATFORM_MAX_PATH];
for(int i = 0; i < studiohdr.numtextures; i++)
{
	Texture t = studiohdr.GetTexture(i);
	t.GetName(texture, sizeof(texture));
	PrintToServer("%d %s", i, texture);
}
```
```
0 alyx_faceandhair
1 eyeball_r
2 eyeball_l
3 hairbits
4 fmouth
5 alyx_sheet
6 alyx_sheet_skin
```